### PR TITLE
Exclude "staging.tmp" from builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,7 @@ install:
 
 script:
   - npm test
+
+branches:
+  except:
+    - staging.tmp


### PR DESCRIPTION
This will prevent bors from spamming the PR with warnings