### PR TITLE
feat(homepage) Basic homepage that displays latest talks and tutorials

### DIFF
--- a/app/components/talk-item.js
+++ b/app/components/talk-item.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+export default Component.extend({});

--- a/app/components/tutorial-item.js
+++ b/app/components/tutorial-item.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const {
+  Component
+} = Ember;
+
+export default Component.extend({});

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,9 +1,21 @@
 import Ember from 'ember';
 
-const { Route } = Ember;
+const {
+  Route,
+  RSVP
+} = Ember;
 
 export default Route.extend({
-  beforeModel() {
-    this.transitionTo('talks');
+  titleToken: 'Learn about Ember.js',
+  model() {
+    return RSVP.hash({
+      talks: this.store.findAll('talk').then((result) => result.toArray().reverse().slice(0, 3)),
+      tutorials: this.store.findAll('tutorial').then((result) => result.toArray().reverse().slice(0, 3))
+    });
+  },
+
+  setupController(controller, models) {
+    controller.setProperties(models);
   }
+
 });

--- a/app/styles/base.scss
+++ b/app/styles/base.scss
@@ -74,7 +74,7 @@ nav{
         font-size:17px;
 
         padding-left: 48px;
-        background-image: url(../images/logo.svg);
+        background-image: url('../images/logo.svg');
         background-position: 0;
         background-size: 40px auto;
         background-repeat: no-repeat;
@@ -128,6 +128,18 @@ ul.tabs{
   }
 }
 
+.hello{
+  margin:60px auto;
+  font-size:20px;
+  line-height:30px;
+  text-align:center;
+  max-width:640px;
+
+  & h1{
+    font-size:28px;
+  }
+}
+
 
 /* MAIN CONTENT */
 section{
@@ -135,6 +147,15 @@ section{
     margin:0px;
     padding:0px;
     list-style:none;
+
+    &.homepage {
+      padding-top: 40px;
+
+      & li {
+        padding-bottom: 40px;
+        margin-bottom: 0px;
+      }
+    }
 
     & li{
       margin-bottom:30px;
@@ -175,6 +196,36 @@ section{
         & a{
           color:#2ba6cb;
           text-decoration:none;
+        }
+      }
+    }
+  }
+
+  & li {
+    margin-bottom: 30px;
+    position: relative;
+
+    & h1 {
+      font-size: 24px;
+      margin: 0px;
+      margin-bottom: 20px;
+
+      & a {
+        background: #2ba6cb;
+        float: right;
+        font-size: 15px;
+        text-decoration: none;
+        color: #FFF;
+        border: 2px solid #2ba6cb;
+        border-radius: 50px;
+        padding: 4px 8px;
+        line-height: 20px;
+
+        &:hover {
+          background: #fff;
+          color: #2ba6cb;
+          text-decoration: none;
+          border: 2px solid #2ba6cb;
         }
       }
     }

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -3,10 +3,10 @@
     <ul>
       <li class="name">
         <h1>
-          <a href="/">
+          {{#link-to 'index'}}
             <i class="foundicon-glasses"></i> Ember<span class="light">Watch</span>
-          </a>
-        </h1>
+          {{/link-to}}
+}        </h1>
       </li>
     </ul>
 

--- a/app/templates/components/talk-item.hbs
+++ b/app/templates/components/talk-item.hbs
@@ -1,0 +1,35 @@
+<li class="thumbnail_enabled">
+  {{#if talk.thumbnail}}
+    <div class="thumbnail video"
+         style={{talk.thumbnailStyle}}
+           data-test-talk-thumbnail-id={{talk.id}}>
+    </div>
+  {{else}}
+    <div class="thumbnail default"></div>
+  {{/if}}
+  <h5>
+    <a href="{{talk.firstVideo}}" data-test-talk-title-id={{talk.id}}>{{talk.title}}</a>
+    {{#if talk.event}}
+      <span class="event-name">
+        {{talk.event.name}}
+      </span>
+    {{/if}}
+    <a target="_blank" href="{{talk.firstVideo}}">
+      <img src="/images/link-new-tab.png" style="vertical-align: bottom">
+    </a>
+  </h5>
+  <div class="metadata">
+    {{#each talk.authors as |author|}}
+      {{#if author.site}}
+        <a href="{{author.site}}" class="has-divider" data-test-talk-id-author="{{talk.id}}">{{author.name}}</a>
+      {{else}}
+        <span class="has-divider">{{author.name}}</span>
+      {{/if}}
+    {{/each}}
+    <span class="has-divider">{{moment-format talk.date 'MMM Do YYYY' 'MM-DD-YYYY'}}</span>
+    <a class="has-divider" href="{{talk.firstVideo}}">Video</a>
+    {{#if talk.slides}}
+      <a class="has-divider" href="{{talk.slides}}">Slides</a>
+    {{/if}}
+  </div>
+</li>

--- a/app/templates/components/tutorial-item.hbs
+++ b/app/templates/components/tutorial-item.hbs
@@ -1,0 +1,18 @@
+{{yield}}
+<li>
+  <h5>
+    {{#each tutorial.parts as |part|}}
+      <a class="tutorials__title" href="{{part.url}}" data-test-tutorial-title-id="{{tutorial.id}}">{{part.title}}</a>
+    {{/each}}
+  </h5>
+  <div class="metadata">
+    {{#each tutorial.authors as |author|}}
+      {{#if author.site}}
+        <a href="{{author.site}}" class="has-divider" data-test-tutorial-id-author="{{tutorial.id}}">{{author.name}}</a>
+      {{else}}
+        <span class="has-divider">{{author.name}}</span>
+      {{/if}}
+    {{/each}}
+    <span class="has-divider">{{moment-format tutorial.date 'MMM Do YYYY' 'MM-DD-YYYY'}}</span>
+  </div>
+</li>

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -4,7 +4,7 @@
     Welcome to EmberWatch
   </h1>
   <p>
-    EmberWatch is a community-run resource for EmberJS. Here you'll find keynotes, useful books, tutorials and more!
+    EmberWatch is a community-run resource hub for all things Ember.js. Here you'll find keynotes, useful books, tutorials and more!
   </p>
 </div>
 

--- a/app/templates/index.hbs
+++ b/app/templates/index.hbs
@@ -1,0 +1,24 @@
+{{outlet}}
+<div class="hello">
+  <h1>
+    Welcome to EmberWatch
+  </h1>
+  <p>
+    EmberWatch is a community-run resource for EmberJS. Here you'll find keynotes, useful books, tutorials and more!
+  </p>
+</div>
+
+<ul class="homepage">
+  <li>
+    <h1>Latest Talks {{#link-to 'talks'}}View All{{/link-to}}</h1>
+    {{#each talks as |talk|}}
+      {{talk-item talk=talk}}
+    {{/each}}
+  </li>
+  <li>
+    <h1>Latest Tutorials {{#link-to 'tutorials'}}View All{{/link-to}}</h1>
+    {{#each tutorials as |tutorial|}}
+      {{tutorial-item tutorial=tutorial}}
+    {{/each}}
+  </li>
+</ul>

--- a/app/templates/talks.hbs
+++ b/app/templates/talks.hbs
@@ -5,41 +5,7 @@
     {{#each talksSorted as |month|}}
       <h2 data-test-talk-month-header="{{month.value}}">{{moment-format month.value 'MMMM YYYY' 'YYYY-MM'}}</h2>
       {{#each month.items as |talk|}}
-        <li class="thumbnail_enabled">
-          {{#if talk.thumbnail}}
-            <div class="thumbnail video"
-                 style={{talk.thumbnailStyle}}
-                   data-test-talk-thumbnail-id={{talk.id}}>
-            </div>
-          {{else}}
-            <div class="thumbnail default"></div>
-          {{/if}}
-          <h5>
-            <a href="{{talk.firstVideo}}" data-test-talk-title-id={{talk.id}}>{{talk.title}}</a>
-            {{#if talk.event}}
-              <span class="event-name">
-                {{talk.event.name}}
-              </span>
-            {{/if}}
-            <a target="_blank" href="{{talk.firstVideo}}">
-              <img src="/images/link-new-tab.png" style="vertical-align: bottom">
-            </a>
-          </h5>
-          <div class="metadata">
-            {{#each talk.authors as |author|}}
-              {{#if author.site}}
-                <a href="{{author.site}}" class="has-divider" data-test-talk-id-author="{{talk.id}}">{{author.name}}</a>
-              {{else}}
-                <span class="has-divider">{{author.name}}</span>
-              {{/if}}
-            {{/each}}
-            <span class="has-divider">{{moment-format talk.date 'MMM Do YYYY' 'MM-DD-YYYY'}}</span>
-            <a class="has-divider" href="{{talk.firstVideo}}">Video</a>
-            {{#if talk.slides}}
-              <a class="has-divider" href="{{talk.slides}}">Slides</a>
-            {{/if}}
-          </div>
-        </li>
+        {{talk-item talk=talk}}
       {{/each}}
     {{/each}}
   </ul>

--- a/app/templates/tutorials.hbs
+++ b/app/templates/tutorials.hbs
@@ -5,23 +5,7 @@
     {{#each tutorialsSorted as |month|}}
       <h2 data-test-tutorial-month-header="{{month.value}}">{{moment-format month.value 'MMMM YYYY' 'YYYY-MM'}}</h2>
       {{#each month.items as |tutorial|}}
-        <li>
-          <h5>
-            {{#each tutorial.parts as |part|}}
-              <a class="tutorials__title" href="{{part.url}}" data-test-tutorial-title-id="{{tutorial.id}}">{{part.title}}</a>
-            {{/each}}
-          </h5>
-          <div class="metadata">
-            {{#each tutorial.authors as |author|}}
-              {{#if author.site}}
-                <a href="{{author.site}}" class="has-divider" data-test-tutorial-id-author="{{tutorial.id}}">{{author.name}}</a>
-              {{else}}
-                <span class="has-divider">{{author.name}}</span>
-              {{/if}}
-            {{/each}}
-            <span class="has-divider">{{moment-format tutorial.date 'MMM Do YYYY' 'MM-DD-YYYY'}}</span>
-          </div>
-        </li>
+        {{tutorial-item tutorial=tutorial}}
       {{/each}}
     {{/each}}
   </ul>

--- a/tests/acceptance/index-test.js
+++ b/tests/acceptance/index-test.js
@@ -1,0 +1,15 @@
+import { test } from 'qunit';
+import moduleForAcceptance from 'emberwatch-ember/tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | index');
+
+test('visiting /', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+    assert.equal(find('.hello h1').text().trim(), 'Welcome to EmberWatch');
+
+  });
+});
+


### PR DESCRIPTION
This is a basic proposal for new homepage. It renders like this:

![screenshot 2017-02-10 22 24 06](https://cloud.githubusercontent.com/assets/13806/22844867/6ca9cffc-efe0-11e6-993d-ff2c19f8acb9.png)

I've started with this PR: https://github.com/emberwatch/emberwatch/pull/42 but it's not a good for current data model. There is one main problem with this design - it assumes we have good cover images.

For talks, we currently can't get Vimeo thumbnails, because they're behind an authenticated API call.
For tutorials and screen podcasts, it's also not clear what visual material we would display.

It could be potentially possible with screencasts, but still only if they're hosted on Youtube. 

Overall, we're quite limited with what we have in our current database.

Hence, this simple refactor of talks and tutorials elements to surface them on homepage. We can make it more visually pleasing at a later point.

At this point I'd just like to get basic feedback on this idea and if it's acceptable, I'll clean PR a bit more and write tests.